### PR TITLE
Disable GORM soft delete

### DIFF
--- a/pkg/api/teams/update.go
+++ b/pkg/api/teams/update.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/hackclub/hack-as-a-service/pkg/api/util"
 	"github.com/hackclub/hack-as-a-service/pkg/db"
-	"gorm.io/gorm"
 )
 
 func handlePATCHTeam(c *gin.Context) {
@@ -41,7 +40,7 @@ func handlePATCHTeam(c *gin.Context) {
 		}
 
 		addUsers = append(addUsers, db.User{
-			Model: gorm.Model{
+			Model: db.Model{
 				ID: u,
 			},
 		})
@@ -49,7 +48,7 @@ func handlePATCHTeam(c *gin.Context) {
 
 	for _, u := range json.RemoveUsers {
 		removeUsers = append(removeUsers, db.User{
-			Model: gorm.Model{
+			Model: db.Model{
 				ID: u,
 			},
 		})

--- a/pkg/db/apps.go
+++ b/pkg/db/apps.go
@@ -1,9 +1,7 @@
 package db
 
-import "gorm.io/gorm"
-
 type App struct {
-	gorm.Model
+	Model
 	Name string
 	// The app's Dokku name
 	ShortName string

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -3,10 +3,18 @@ package db
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
+
+// Model is a clone of a gorm.Model, but without the `DeletedAt` field
+type Model struct {
+	ID        uint `gorm:"primarykey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
 
 var DB *gorm.DB
 

--- a/pkg/db/teams.go
+++ b/pkg/db/teams.go
@@ -1,9 +1,7 @@
 package db
 
-import "gorm.io/gorm"
-
 type Team struct {
-	gorm.Model
+	Model
 	Name      string
 	Avatar    string
 	Automatic bool    // Whether the team was created automatically for ad-hoc app sharing

--- a/pkg/db/tokens.go
+++ b/pkg/db/tokens.go
@@ -2,15 +2,12 @@ package db
 
 import (
 	"time"
-
-	"gorm.io/gorm"
 )
 
 type Token struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	DeletedAt gorm.DeletedAt `gorm:"index"`
-	Token     string         `gorm:"primarykey"`
+	Token     string `gorm:"primarykey"`
 	ExpiresAt time.Time
 	UserID    uint
 }

--- a/pkg/db/users.go
+++ b/pkg/db/users.go
@@ -1,11 +1,7 @@
 package db
 
-import (
-	"gorm.io/gorm"
-)
-
 type User struct {
-	gorm.Model
+	Model
 	SlackUserID string `gorm:"unique"`
 	Name        string
 	Avatar      string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -603,11 +603,6 @@ components:
         UpdatedAt:
           type: string
           format: date-time
-        DeletedAtTime:
-          type: string
-          format: date-time
-        DeletedAtValid:
-          type: boolean
     Status:
       type: string
       enum: [ok]


### PR DESCRIPTION
This PR disables GORM soft delete by removing the `DeleteAt` field from the model struct

Reference:
https://gorm.io/docs/delete.html#Soft-Delete
> If your model includes a `gorm.DeletedAt` field (which is included in `gorm.Model`), it will get soft delete ability automatically