### PR TITLE
Update team avatar via API

### DIFF
--- a/pkg/api/teams/update.go
+++ b/pkg/api/teams/update.go
@@ -19,6 +19,7 @@ func handlePATCHTeam(c *gin.Context) {
 
 	var json struct {
 		Name        string
+		Avatar      string
 		AddUsers    []uint
 		RemoveUsers []uint
 	}
@@ -75,7 +76,7 @@ func handlePATCHTeam(c *gin.Context) {
 	}
 
 	// will only update the field if Name != ""
-	result = db.DB.Model(&team).Updates(&db.Team{Name: json.Name})
+	result = db.DB.Model(&team).Updates(&db.Team{Name: json.Name, Avatar: json.Avatar})
 	if result.Error != nil {
 		c.JSON(500, gin.H{"status": "error", "message": result.Error.Error()})
 		return

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -228,6 +228,8 @@ paths:
               properties:
                 Name:
                   type: string
+                Avatar:
+                  type: string
                 AddUsers:
                   type: array
                   items:


### PR DESCRIPTION
This PR adds an `Avatar` field to the `PATCH /teams/:id` endpoint.