### PR TITLE
Fix build logs

### DIFF
--- a/frontend/pages/apps/[id]/deploy.tsx
+++ b/frontend/pages/apps/[id]/deploy.tsx
@@ -51,7 +51,7 @@ export default function AppDeployPage(props: {
           </Text>
         </Text>
         <Input name="repoUrl" type="url" required ref={repoUrlRef} />
-        <Button variant="ctaLg" mt={2}>
+        <Button variant="ctaLg" mt={2} type="submit">
           Deploy
         </Button>
       </Box>

--- a/pkg/api/builds/logs.go
+++ b/pkg/api/builds/logs.go
@@ -3,6 +3,7 @@ package builds
 import (
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -54,7 +55,7 @@ loop:
 			if !ok {
 				continue
 			}
-			err := ws.WriteJSON(gin.H{"Stream": "stdout", "Output": line})
+			err := ws.WriteJSON(gin.H{"Timestamp": time.Now().UnixNano(), "Stream": "stdout", "Output": line})
 			switch err.(type) {
 			case *websocket.CloseError:
 				break loop
@@ -63,13 +64,13 @@ loop:
 			if !ok {
 				continue
 			}
-			err := ws.WriteJSON(gin.H{"Stream": "stderr", "Output": line})
+			err := ws.WriteJSON(gin.H{"Timestamp": time.Now().UnixNano(), "Stream": "stderr", "Output": line})
 			switch err.(type) {
 			case *websocket.CloseError:
 				break loop
 			}
 		case status := <-cmd.StatusChan:
-			err = ws.WriteJSON(gin.H{"Stream": "status", "Output": strconv.Itoa(status)})
+			err = ws.WriteJSON(gin.H{"Timestamp": time.Now().UnixNano(), "Stream": "status", "Output": strconv.Itoa(status)})
 			if err != nil {
 				log.Println(err)
 			}


### PR DESCRIPTION
Timestamps are now recorded on build logs to the nanosecond. This allows them to be stored unordered in the database (due to other factors) and still allows the frontend to sort and display them properly.

Fixes #171 

I will merge manually after nuking the builds table.